### PR TITLE
Removed single-touch check from endTouch

### DIFF
--- a/lib/userinput/touch.js
+++ b/lib/userinput/touch.js
@@ -140,15 +140,7 @@ function touch($element, boundingBox, onStart, onInput, onEnd, onChange) {
 
         // end event might be triggered twice (document)
         event.stopPropagation();
-
-        // if touch remains, change mode
-        if (event.touches.length === 1) {
-            // reset
-            startSingleTouch(event.touches[0]);
-            onChange(currentPosition);
-            return;
-        }
-
+        
         // else end input action
         considerStart = false;
         currentTouches = 0;


### PR DESCRIPTION
Making a check for a single-fingered touch in endTouch was causing sling-shot behavior if the timing of lifting the fingers was off. As our use-case would never involve transitioning between a two-finger touch directly into a one-finger touch (without lifting the fingers), eliminating this check was a quick way to solve the sling-shot problem.